### PR TITLE
Update permissions to fix db initialization permission errors

### DIFF
--- a/ge_getting_started_tutorial/Dockerfile
+++ b/ge_getting_started_tutorial/Dockerfile
@@ -2,3 +2,4 @@ FROM postgres:12
 
 COPY ./data/*.csv /tmp/
 COPY ./data/ /docker-entrypoint-initdb.d/
+RUN chmod 775 /docker-entrypoint-initdb.d/* /tmp/*.csv


### PR DESCRIPTION
Fixes errors like those below when running `docker-compose up` following instructions at https://docs.greatexpectations.io/en/latest/guides/tutorials/getting_started/initialize_a_data_context.html#set-up-your-machine-for-the-tutorial

```
postgres_1  | psql: error: /docker-entrypoint-initdb.d/load_data.sql: Permission denied
```

And:

```
postgres_1  | psql:/docker-entrypoint-initdb.d/load_data.sql:27: error: /tmp/yellow_tripdata_sample_2019-01.csv: Permission denied
```