### PR TITLE
Update great_expectations.yml

### DIFF
--- a/ge_dbt_airflow_tutorial/great_expectations_projects/final/great_expectations/great_expectations.yml
+++ b/ge_dbt_airflow_tutorial/great_expectations_projects/final/great_expectations/great_expectations.yml
@@ -82,12 +82,13 @@ data_docs_sites:
   # profiles from the uncommitted directory. Read more at https://docs.greatexpectations.io/en/latest/features/data_docs.html
   local_site:
     class_name: SiteBuilder
+    # set to false to hide how-to buttons in Data Docs
+    show_how_to_buttons: true
     store_backend:
       class_name: TupleFilesystemStoreBackend
       base_directory: uncommitted/data_docs/local_site/
     site_index_builder:
       class_name: DefaultSiteIndexBuilder
-      show_cta_footer: true
 anonymous_usage_statistics:
   data_context_id: a3454240-fa69-4c9a-904b-726fac29c60b
   enabled: false


### PR DESCRIPTION
use `show_how_to_buttons` instead of `show_cta_footer`
show_cta_footer was removed in PR #1249
See also https://github.com/great-expectations/great_expectations/pull/2190