### PR TITLE
[FEATURE] Adding basic example to V3

### DIFF
--- a/getting_started_tutorial_final_v3_api/run_checkpoint_with_expectation_suite.py
+++ b/getting_started_tutorial_final_v3_api/run_checkpoint_with_expectation_suite.py
@@ -1,0 +1,11 @@
+import great_expectations as ge
+
+# add great_expectations/plugins to path
+import sys, os
+sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), 'great_expectations'))
+
+from plugins import column_custom_max_expectation
+
+context = ge.get_context()
+context.run_checkpoint(checkpoint_name="my_checkpoint")
+context.open_data_docs()


### PR DESCRIPTION
* getting started tutorial for V3 contains a script for 1 of the 2 ExpectationSuites. This PR proposes adding a script that runs the checkpoint for the remaining Suite. 